### PR TITLE
Update COP-DEM specs

### DIFF
--- a/data_specs/COP_DEM_specs.ipynb
+++ b/data_specs/COP_DEM_specs.ipynb
@@ -9,6 +9,12 @@
    ]
   },
   {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "**Date modified:** 09 May 2025",
+   "id": "8a0dc2e9e7f09710"
+  },
+  {
    "cell_type": "markdown",
    "id": "623b1e88-a52d-449f-b7ab-a308634aad0e",
    "metadata": {},

--- a/data_specs/COP_DEM_specs.ipynb
+++ b/data_specs/COP_DEM_specs.ipynb
@@ -40,8 +40,7 @@
     "\n",
     "There are two instances of the COP-DEM-GLO-30 Copernicus DEM: COP-DEM-GLO-30-R and COP-DEM-GLO-30 Public. \n",
     "COP-DEM-GLO-30 Public provides limited worldwide coverage at 1.0 arc seconds (~30m) spatial resolution because a small subset of tiles covering specific countries are not yet released to the public by the Copernicus Programme. \n",
-    "The list of countries presenting constraints in terms of access rights is available [here](https://spacedata.copernicus.eu/documents/20126/0/Non-released-tiles_GLO-30_PUBLIC_Dec.xlsx/bcdd6cef-6379-4890-de8f-788daf41dce8?t=1608549440765). \n",
-    "COP-DEM-GLO-30-R provides complete global coverage, but is only accessible to users belonging to the authorised users categories as defined in the [applicable license](https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex.pdf/5308d1e7-17de-b55b-2be8-8a3a286aa88b?t=1581077110498). "
+    "The list of countries presenting constraints in terms of access rights is available [here](https://sentinel.esa.int/documents/247904/4624006/Non-released-tiles-GLO-30-PUBLIC-Dec.xlsx). COP-DEM-GLO-30-R provides complete global coverage, but is only accessible to users belonging to the authorised users categories as defined in the [applicable license](https://s3.waw3-1.cloudferro.com/swift/v1/portal_uploads_prod/CSCDA_ESA_Mission-specific_Annex_31_Oct_22_latest.pdf)."
    ]
   },
   {
@@ -50,7 +49,7 @@
    "metadata": {},
    "source": [
     "Digital Earth Africa provides free and open access to a copy of the COP-DEM-GLO-30 Public and COP-DEM-GLO-90 products over Africa. \n",
-    "For more information on these products see the [Copernicus DEM website](https://spacedata.copernicus.eu/web/cscda/dataset-details?articleId=394198) and [Copernicus DEM Product Handbook](https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-SPE-002_ProductHandbook_I3.0+%281%29.pdf/68854203-e022-1446-b216-41becd2399b5?t=1618937501277).\n",
+    "For more information on these products see the [Copernicus DEM website](https://doi.org/10.5270/ESA-c5d3d65) and [Copernicus DEM Product Handbook](https://dataspace.copernicus.eu/sites/default/files/media/files/2024-06/geo1988-copernicusdem-spe-002_producthandbook_i5.0.pdf).\n",
     "\n",
     "A [Jupyter Notebook](https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/blob/main/Datasets/Digital_Elevation_Models.ipynb) which demonstrates loading and using DEM datasets in the Sandbox is also available."
    ]
@@ -75,9 +74,7 @@
    "cell_type": "markdown",
    "id": "07233424-1cbf-4591-9ad9-831ee90129c2",
    "metadata": {},
-   "source": [
-    "Relevant metadata for the COP-DEM-GLO-30 Public and COP-DEM-GLO-90 products can be viewed on the DE Africa Metadata Explorer [here](https://explorer.digitalearth.africa/products/dem_cop_30) and [here](https://explorer.digitalearth.africa/products/dem_cop_90)."
-   ]
+   "source": "Relevant metadata for the COP-DEM-GLO-30 Public and COP-DEM-GLO-90 products as well as their temporal and geographic extents can be viewed on the interactive DE Africa Metadata Explorer [here](https://explorer.digitalearth.africa/products/dem_cop_30) and [here](https://explorer.digitalearth.africa/products/dem_cop_90). Data is available for the regions shaded in blue."
   },
   {
    "cell_type": "markdown",
@@ -99,14 +96,6 @@
     "|Cell size - Y (arc seconds) | 1.0 (~30 m) | 3.0 (~90 m) |\n",
     "|Coordinate reference system | EPSG: 4326 | EPSG: 4326 |\n",
     "|Update frequency| None, except if the public tile list changes. | None |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0ab50612-09f8-4fd5-a68d-96cfc58e302e",
-   "metadata": {},
-   "source": [
-    "The specific temporal and geographic extents for the products can be explored as an interactive map on the Metadata Explorer [here](https://explorer.digitalearth.africa/products/dem_cop_30) and [here](https://explorer.digitalearth.africa/products/dem_cop_90). Data is available for the regions shaded in blue."
    ]
   },
   {
@@ -184,7 +173,7 @@
     "The Copernicus DEM  is derived from an edited DSM named WorldDEM which was based on the radar satellite data acquired during the TanDEM-X Mission. \n",
     "For the edited WorldDEM, the flattening of water bodies and consistent flow of rivers has been included, and editing of shore- and coastlines, special features such as airports and implausible terrain structures has also been applied. \n",
     "The edited WorldDEM was also infilled on a local basis with the following DEMs: ASTER, SRTM90, SRTM30, SRTM30plus, GMTED2010, TerraSAR-X Radargrammetric DEM, ALOS World 3D-30m.\n",
-    "The Copernicus DEM product generation and editing process is described in the [Product Handbook](https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-SPE-002_ProductHandbook_I3.0+%281%29.pdf/68854203-e022-1446-b216-41becd2399b5?t=1618937501277)."
+    "The Copernicus DEM product generation and editing process is described in the [Product Handbook](https://dataspace.copernicus.eu/sites/default/files/media/files/2024-06/geo1988-copernicusdem-spe-002_producthandbook_i5.0.pdf)."
    ]
   },
   {
@@ -239,17 +228,13 @@
    "cell_type": "markdown",
    "id": "329c0ceb-4622-493b-9cf0-0b64708f314f",
    "metadata": {},
-   "source": [
-    "The [Copernicus DEM website](https://spacedata.copernicus.eu/web/cscda/dataset-details?articleId=394198)"
-   ]
+   "source": "The [Copernicus DEM website](https://doi.org/10.5270/ESA-c5d3d65)"
   },
   {
    "cell_type": "markdown",
    "id": "7570c0e3-9c08-4433-9194-10b44d317f8a",
    "metadata": {},
-   "source": [
-    "The [Copernicus DEM Product Handbook](https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-SPE-002_ProductHandbook_I3.0+%281%29.pdf/68854203-e022-1446-b216-41becd2399b5?t=1618937501277)"
-   ]
+   "source": "The [Copernicus DEM Product Handbook](https://dataspace.copernicus.eu/sites/default/files/media/files/2024-06/geo1988-copernicusdem-spe-002_producthandbook_i5.0.pdf)"
   },
   {
    "cell_type": "markdown",
@@ -263,9 +248,7 @@
    "cell_type": "markdown",
    "id": "b0a02f8b-fa23-4263-bdbf-de25dc7bb787",
    "metadata": {},
-   "source": [
-    "The GLO-90 dataset is available worldwide with a free license. The GLO-30 dataset is available worldwide with a free license with the exception of two countries, reported in a [dedicated list](https://spacedata.copernicus.eu/documents/20126/0/COP-DEM_delivery_sheet_v0.9.xlsx/9812e3a5-300d-a0ef-1c52-4d55391eaed8?t=1630080852713) and available within the dataset COP-DEM_GLO-30-R. Full licences are available [here](https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex+%281%29.pdf/83b44c0a-244a-7ba3-b00c-b578a34e88a7?t=1604070311399)."
-   ]
+   "source": "The GLO-90 dataset is available worldwide with a free license. The GLO-30 dataset is available worldwide with a free license with the exception of two countries, reported in a [dedicated list](https://spacedata.copernicus.eu/documents/20126/0/COP-DEM_delivery_sheet_v0.9.xlsx/9812e3a5-300d-a0ef-1c52-4d55391eaed8?t=1630080852713) and available within the dataset COP-DEM_GLO-30-R. Full licences are available [here](https://s3.waw3-1.cloudferro.com/swift/v1/portal_uploads_prod/CSCDA_ESA_Mission-specific_Annex_31_Oct_22_latest.pdf)."
   },
   {
    "cell_type": "markdown",
@@ -452,7 +435,7 @@
    "source": [
     "The Copernicus DEM was validated using the Geoscience Laser Altimeter System (GLAS) of NASA’s Ice, Cloud and land Elevation Satellite (ICESat). \n",
     "The Global *RMSE* is 1.68 metres. \n",
-    "The accuracy assessment is split into two parts, since the ice-covered regions have to be treated differently from the non-ice-covered regions, which are described in the [Validation Report](https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-RP-001_ValidationReport_I3.0.pdf/996b90c4-49b1-0883-5553-4e29a29c4bd5?t=1609340156005)."
+    "The accuracy assessment is split into two parts, since the ice-covered regions have to be treated differently from the non-ice-covered regions, which are described in the [Validation Report](https://s3.waw3-1.cloudferro.com/swift/v1/portal_uploads_prod/GEO1988-CopernicusDEM-RP-001_ValidationReport_I3.0_08.2024.pdf)."
    ]
   }
  ],


### PR DESCRIPTION
I noticed some outdated URLs in the Copernicus DEM spec, which are updated in this PR. The URL to the Copernicus DEM website is replaced with its DOI version, which hopefully stays up-to-date in case of future URL changes of the website. 

I also merged the text above and below Table 1, which refers to the metadata explorer. 